### PR TITLE
Relax blacklight dependency to fix the build

### DIFF
--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hydra-head', '>= 10.4.0'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
   spec.add_dependency 'browse-everything', '>= 0.10.3'
-  spec.add_dependency 'blacklight', '~> 6.6'
+  # 6.10 drops rails 4 support. this should allow rails 5.0, but not 5.1
+  spec.add_dependency 'blacklight', '~> 6.6', '<6.10'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
   spec.add_dependency 'tinymce-rails-imageupload', '~> 4.0.16.beta'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hydra-head', '>= 10.4.0'
   spec.add_dependency 'hydra-batch-edit', '~> 2.0'
   spec.add_dependency 'browse-everything', '>= 0.10.3'
-  # Workaround for https://github.com/projecthydra-labs/hyrax/issues/546
-  spec.add_dependency 'blacklight', '~> 6.6', '< 6.8.0'
+  spec.add_dependency 'blacklight', '~> 6.6'
   spec.add_dependency 'blacklight-gallery', '~> 0.7'
   spec.add_dependency 'tinymce-rails', '~> 4.1'
   spec.add_dependency 'tinymce-rails-imageupload', '~> 4.0.16.beta'

--- a/sufia.gemspec
+++ b/sufia.gemspec
@@ -48,6 +48,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'flipflop', '~> 2.3'
   spec.add_dependency 'jquery-datatables-rails', '~> 3.4.0'
   spec.add_dependency 'rdf-rdfxml'
+  # https://github.com/svenfuchs/i18n/issues/379
+  spec.add_dependency 'i18n', '0.8.1'
 
   spec.add_development_dependency 'engine_cart', '~> 1.0'
   spec.add_development_dependency 'mida', '~> 0.3'


### PR DESCRIPTION
Lower blacklight generators insert an rsolr 1.0 requirement into the Gemfile, which was conflicting with sufia dependencies.

This is backwards compatible, since the issue only affects app generation. I believe this can be released as a point release.

@projecthydra/sufia-code-reviewers
